### PR TITLE
Update version of boost

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,15 +79,11 @@ def get_pipeline(image_key) {
               --build=outdated
           \""""
 
-          // There is a problem with the boost packages on alpine until we can update
-          // to boost 1.67 or above
-          if (image_key != 'alpine') {
-            sh """docker exec ${container_name} ${custom_sh} -c \"
-              conan install ${project}/conanfile_boost.txt \
-                --settings build_type=Release \
-                --build=outdated
-            \""""
-          }
+          sh """docker exec ${container_name} ${custom_sh} -c \"
+            conan install ${project}/conanfile_boost.txt \
+              --settings build_type=Release \
+              --build=outdated
+          \""""
 
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan install gtest/1.8.0@conan/stable \
@@ -150,16 +146,11 @@ def get_pipeline(image_key) {
                 --build=outdated
             \""""
           } else {
-            // There is a problem with the boost packages on alpine until we can update
-            // to boost 1.67 or above
-            if (image_key != 'alpine') {
-              // boost_log 1.65.1 does not build on CentOS because of boost_python.
-              sh """docker exec ${container_name} ${custom_sh} -c \"
-                conan install boost_log/1.65.1@bincrafters/stable \
-                  --options boost_filesystem:shared=True \
-                  --build=outdated
-              \""""
-            }
+            sh """docker exec ${container_name} ${custom_sh} -c \"
+              conan install boost_log/1.65.1@bincrafters/stable \
+                --options boost_filesystem:shared=True \
+                --build=outdated
+            \""""
 
             // Delete duplicate packages, as they can cause upload problems.
             sh """docker exec ${container_name} ${custom_sh} -c \"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,7 +133,7 @@ def get_pipeline(image_key) {
           if (image_key == 'centos7') {
             // There is only one cmake_findboost_modular package.
             sh """docker exec ${container_name} ${custom_sh} -c \"
-              conan install cmake_findboost_modular/1.65.1@bincrafters/stable \
+              conan install cmake_findboost_modular/1.69.0@bincrafters/stable \
                 --build=outdated
             \""""
 
@@ -150,7 +150,7 @@ def get_pipeline(image_key) {
             \""""
           } else {
             sh """docker exec ${container_name} ${custom_sh} -c \"
-              conan install boost_log/1.65.1@bincrafters/stable \
+              conan install boost_log/1.69.0@bincrafters/stable \
                 --options shared=True \
                 --build=outdated
             \""""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,10 +79,13 @@ def get_pipeline(image_key) {
               --build=outdated
           \""""
 
+          // Note, we explicitly rebuild boost_build because the packaged version
+          // is built against glibc, but on alpine it needs to be built against musl
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan install ${project}/conanfile_boost.txt \
               --settings build_type=Release \
-              --build=outdated
+              --build=outdated \
+              --build=boost_build
           \""""
 
           sh """docker exec ${container_name} ${custom_sh} -c \"
@@ -148,7 +151,7 @@ def get_pipeline(image_key) {
           } else {
             sh """docker exec ${container_name} ${custom_sh} -c \"
               conan install boost_log/1.65.1@bincrafters/stable \
-                --options boost_filesystem:shared=True \
+                --options shared=True \
                 --build=outdated
             \""""
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,13 @@ def get_pipeline(image_key) {
               --settings build_type=Release \
               --build=outdated
           \""""
+          
+          // force boost_build to build before any other boost package
+          // workaround for this bug: https://github.com/bincrafters/community/issues/705
+          sh """docker exec ${container_name} ${custom_sh} -c \"
+            conan install boost_build/1.69.0@bincrafters/stable \
+              --build
+          \""""
 
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan install ${project}/conanfile_boost.txt \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,13 +78,6 @@ def get_pipeline(image_key) {
               --settings build_type=Release \
               --build=outdated
           \""""
-          
-          // force boost_build to build before any other boost package
-          // workaround for this bug: https://github.com/bincrafters/community/issues/705
-          sh """docker exec ${container_name} ${custom_sh} -c \"
-            conan install boost_build/1.69.0@bincrafters/stable \
-              --build
-          \""""
 
           sh """docker exec ${container_name} ${custom_sh} -c \"
             conan install ${project}/conanfile_boost.txt \

--- a/conanfile_boost.txt
+++ b/conanfile_boost.txt
@@ -1,15 +1,16 @@
 [requires]
-boost_date_time/1.65.1@bincrafters/stable
-boost_filesystem/1.65.1@bincrafters/stable
-boost_program_options/1.65.1@bincrafters/stable
-boost_asio/1.65.1@bincrafters/stable
-boost_property_tree/1.65.1@bincrafters/stable
-boost_thread/1.65.1@bincrafters/stable
-boost_timer/1.65.1@bincrafters/stable
-boost_atomic/1.65.1@bincrafters/stable
-boost_container/1.65.1@bincrafters/stable
-boost_exception/1.65.1@bincrafters/stable
-boost_chrono/1.65.1@bincrafters/stable
+cmake_findboost_modular/1.69.0@bincrafters/stable
+boost_date_time/1.69.0@bincrafters/stable
+boost_filesystem/1.69.0@bincrafters/stable
+boost_program_options/1.69.0@bincrafters/stable
+boost_asio/1.69.0@bincrafters/stable
+boost_property_tree/1.69.0@bincrafters/stable
+boost_thread/1.69.0@bincrafters/stable
+boost_timer/1.69.0@bincrafters/stable
+boost_atomic/1.69.0@bincrafters/stable
+boost_container/1.69.0@bincrafters/stable
+boost_exception/1.69.0@bincrafters/stable
+boost_chrono/1.69.0@bincrafters/stable
 
 [options]
 boost_filesystem:shared=True


### PR DESCRIPTION
Everywhere we are using boost we are now on version `1.69.0`, updating here so that we'll have the relevant binaries on the ESS conan server.

Forces `boost_build` to be rebuilt, so that it is built against `musl` rather than `glibc` on alpine.